### PR TITLE
Added Docker Support for PolarDNS

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,17 @@
+# Use an official Python runtime as a parent image
+FROM python:3.10
+
+# Set the working directory in the container
+WORKDIR /usr/src/app
+
+# Install any needed packages specified in requirements.txt
+RUN pip install pyyaml
+
+# Copy the current directory contents into the container at /usr/src/app
+COPY . .
+
+# Make port 53 available to the world outside this container
+EXPOSE 53/udp 53/tcp
+
+# Run polardns.py when the container launches
+CMD ["python", "polardns.py"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,8 +7,9 @@ WORKDIR /usr/src/app
 # Install any needed packages specified in requirements.txt
 RUN pip install pyyaml
 
-# Copy the current directory contents into the container at /usr/src/app
-COPY . .
+# Copy the required files into the container at /usr/src/app
+COPY polardns.py .
+COPY polardns.yml .
 
 # Make port 53 available to the world outside this container
 EXPOSE 53/udp 53/tcp


### PR DESCRIPTION

- Created a Dockerfile to containerize the PolarDNS application.
- Updated documentation for Docker build and run instructions.

## Building and Running PolarDNS Docker Image

To build the Docker image for PolarDNS:

```bash
docker build -t polar_dns .
```

To run the PolarDNS container:

```bash
docker run -d --name polar_dns_container -p 53:53/tcp -p 53:53/udp polar_dns
```